### PR TITLE
Handle non-XML stackup export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ python main.py
 When prompted to load a layout, choose the `edb.def` file located inside your
 `.aedb` folder. The application will pass the folder to SIwave for import.
 
-The stackup configuration exported by the application is saved as `stack.xml` in the current working directory. Use this file when editing or importing stackup settings.
+The stackup configuration exported by the application is saved as `stackup.xml` in the current working directory. Use this file when editing or importing stackup settings.


### PR DESCRIPTION
## Summary
- add parser for `$begin` style stackup files
- use new parser when opening stackup
- document correct stackup file name

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d44b7a520832a8614636a561edb0c