### PR TITLE
Fix stackup XML formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -228,7 +228,8 @@ class StackupDialog(QDialog):
                 else:
                     loss_el.text = self.tab_material.item(row, 2).text()
 
-        self.tree.write(self.xml_path)
+        ET.indent(self.tree, space="  ")
+        self.tree.write(self.xml_path, encoding="utf-8", xml_declaration=True)
 
     def apply_changes(self):
         self._save_changes()


### PR DESCRIPTION
## Summary
- make stackup.xml readable by indenting

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5117fd30832a9d5e2bcd01f95c66